### PR TITLE
Package dev prior

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -843,7 +843,7 @@ check_arg_options <- function(obj, model, info)
                          "iterations", "verbose",
                          "use_weights", "weights_type", 
                          "prune",
-                         "store_theta", "slice_shape", "store_pi")
+                         "store_theta", "slice_shape")
 
   # llk_per
   if (is.null(obj$llk_per))
@@ -894,13 +894,16 @@ check_arg_options <- function(obj, model, info)
   }
 
   # Store pi
-  if (is.null(obj$store_pi)) {
-    obj$store_pi <- 0L
-  } else {
-    obj$store_pi <- as.integer(obj$store_pi)  
-    if (!obj$store_pi %in% c(0, 1)) {
-      stop("An invalid value in `options$store_theta`")  
+  if (model %in% info$models_keyATM) {
+    if (is.null(obj$store_pi)) {
+      obj$store_pi <- 0L
+    } else {
+      obj$store_pi <- as.integer(obj$store_pi)  
+      if (!obj$store_pi %in% c(0, 1)) {
+        stop("An invalid value in `options$store_theta`")  
+      }
     }
+    allowed_arguments <- c(allowed_arguments, "store_pi")
   }
 
 

--- a/R/model.R
+++ b/R/model.R
@@ -604,6 +604,30 @@ check_arg_model_settings <- function(obj, model, info)
     allowed_arguments <- c(allowed_arguments, "slice_min", "slice_max")
   }
 
+  if (model %in% c("base", "cov", "hmm")) {
+  
+    if (!is.null(obj$labels)) {
+   
+      if (length(obj$labels) != info$num_doc) {
+        stop("The length of `model_settings$labels` does not match with the number of documents")
+      }
+      if (max(obj$labels, na.rm = TRUE) > info$keyword_k | min(obj$labels, na.rm = TRUE) <= 0) {
+        stop("`model_settings$labels` must only contain integer values less than the total number of the keyword topics for labeled documents and `NA` should be assigned to non-labeled documents.")
+      }
+     
+      obj$labels[is.na(obj$labels)] <- 0 # insert -1 to NA values
+      obj$labels <- as.integer(obj$labels) - 1L  # index starts from 0 in C++, you do not need to worry about NA here
+      
+      if (!isTRUE(all(obj$labels == floor(obj$labels)))) {
+        stop("`model_settings$labels` must only contain integer values for labeled documents and `NA` should be assigned to non-labeled documents")
+      }
+    
+    }
+
+    allowed_arguments <- c(allowed_arguments, "labels")
+  
+  }
+
   if (model %in% c("cov", "ldacov")) { 
      if (is.null(obj$covariates_data)) {
       stop("Please provide `obj$covariates_data`.")  

--- a/src/LDA_base.cpp
+++ b/src/LDA_base.cpp
@@ -139,6 +139,13 @@ void LDAbase::initialize_common()
 }
 
 
+void LDAbase::parameters_store(int &r_index)
+{
+  if (store_theta)
+    store_theta_iter(r_index);
+}
+
+
 int LDAbase::sample_z(VectorXd &alpha, int &z, int &s, int &w, int &doc_id)
 {
   // remove data

--- a/src/LDA_base.h
+++ b/src/LDA_base.h
@@ -31,6 +31,7 @@ class LDAbase : virtual public keyATMmeta
     virtual void read_data_common();
     virtual void initialize_common();
     virtual void iteration_single(int &it) = 0;
+    void parameters_store(int &r_index); 
     virtual int sample_z(VectorXd &alpha, int &z, int &s,
                          int &w, int &doc_id) final;
     virtual double loglik_total() = 0;

--- a/src/keyATM_meta.cpp
+++ b/src/keyATM_meta.cpp
@@ -274,11 +274,7 @@ void keyATMmeta::iteration()
       verbose_special(r_index);
     }
     if (r_index % thinning == 0 || r_index == 1 || r_index == iter) {
-      if (store_theta)
-        store_theta_iter(r_index);
-
-      if (store_pi)
-        store_pi_iter(r_index);
+      parameters_store(r_index);
     }
 
     // Progress bar
@@ -311,6 +307,15 @@ void keyATMmeta::sampling_store(int &r_index)
   }
 }
 
+
+void keyATMmeta::parameters_store(int &r_index)
+{
+  if (store_theta)
+    store_theta_iter(r_index);
+
+  if (store_pi)
+    store_pi_iter(r_index);
+}
 
 void keyATMmeta::store_theta_iter(int &r_index)
 {

--- a/src/keyATM_meta.h
+++ b/src/keyATM_meta.h
@@ -68,6 +68,8 @@ class keyATMmeta
     int num_vocab, num_doc, total_words;
     double total_words_weighted;
 
+    VectorXi labels_true;
+
     List options_list;
     List Z_tables;
     List priors_list;
@@ -164,6 +166,7 @@ class keyATMmeta
                    int &w, int &doc_id);
 
     void sampling_store(int &r_index);
+    virtual void parameters_store(int &r_index);
     void store_theta_iter(int &r_index);
     void store_pi_iter(int &r_index);
 


### PR DESCRIPTION
Some functions are updated for storing pi. Could you double-check by trying with sample codes?
The main issue I fixed is that `store_pi` option was passed to weighted LDA models.

Once you check it, could you make a pull request back to `package_dev_prior`? I have some suggestions on the `plot_pi` function. 