### PR TITLE
Make all examples runnable; fixed a bug in weightedLDA().

### DIFF
--- a/R/keyATM.R
+++ b/R/keyATM.R
@@ -56,29 +56,36 @@
 #' @seealso \url{https://keyatm.github.io/keyATM/articles/pkgdown_files/Options.html}
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #'   library(keyATM)
 #'   library(quanteda)
 #'   data(keyATM_data_bills)
 #'   bills_keywords <- keyATM_data_bills$keywords
 #'   bills_dfm <- keyATM_data_bills$doc_dfm  # quanteda dfm object
 #'   keyATM_docs <- keyATM_read(bills_dfm)
+#'
 #'   # keyATM Base
-#'   out <- keyATM(
-#'                 docs, model = "base", no_keyword_topics = 5, keywords = keywords_list
-#'                )
+#'   out <- keyATM(keyATM_docs,
+#'                 model = "base", no_keyword_topics = 5,
+#'                 keywords = bills_keywords)
 #'
 #'   # keyATM Covariates
-#'   out <- keyATM(
-#'                 docs, model = "covariates", no_keyword_topics = 5, keywords = keywords_list,
-#'                 model_settings(covariates_data = cov, covariates_formula = ~ .)
-#'                )
+#'   bills_cov <- as.data.frame(keyATM_data_bills$cov)
+#'   out <- keyATM(keyATM_docs,
+#'          model = "covariates", no_keyword_topics = 5,
+#'          keywords = bills_keywords,
+#'          model_settings = list(covariates_data = bills_cov,
+#'          covariates_formula = ~RepParty))
 #'
 #'   # keyATM Dynamic
-#'   out <- keyATM(
-#'                 docs, model = "dynamic", no_keyword_topics = 5, keywords = keywords_list,
-#'                 model_settings(time_index = time_index_vec, num_states = 5)
-#'                )
+#'   bills_time_index <- keyATM_data_bills$time_index
+#'   # Time index should start from 1, increment by 1
+#'   bills_time_index <- as.integer(bills_time_index - 100)
+#'   out <- keyATM(keyATM_docs,
+#'                 model = "dynamic", no_keyword_topics = 5,
+#'                 keywords = bills_keywords,
+#'                 model_settings = list(num_states = 5,
+#'                 time_index = bills_time_index, num_states = 5))
 #'
 #'   # Visit our website for full examples: https://keyatm.github.io/keyATM/
 #'
@@ -183,23 +190,32 @@ check_arg_keep <- function(obj, model)
 #' @seealso \url{https://keyatm.github.io/keyATM/articles/pkgdown_files/Options.html}
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
+#'   library(keyATM)
+#'   library(quanteda)
+#'   data(keyATM_data_bills)
+#'   bills_keywords <- keyATM_data_bills$keywords
+#'   bills_dfm <- keyATM_data_bills$doc_dfm  # quanteda dfm object
+#'   keyATM_docs <- keyATM_read(bills_dfm)
 #'   # Weighted LDA
-#'   out <- weightedLDA(
-#'                      keyATM_docs, model = "base", number_of_topics = 5
-#'                     )
+#'   out <- weightedLDA(keyATM_docs, model = "base",
+#'                      number_of_topics = 5)
 #'
 #'   # Weighted LDA Covariates
-#'   out <- weightedLDA(
-#'                      keyATM_docs, model = "covariates", number_of_topics = 5,
-#'                      model_settings(covariates_data = cov, covariates_formula = ~ .)
-#'                     )                   
+#'   bills_cov <- as.data.frame(keyATM_data_bills$cov)
+#'   out <- weightedLDA(keyATM_docs, model = "covariates",
+#'          number_of_topics = 5,
+#'          model_settings = list(covariates_data = bills_cov,
+#'          covariates_formula = ~ RepParty))                   
 #'
 #'   # Weighted LDA Dynamic
-#'   out <- weightedLDA(
-#'                      keyATM_docs, model = "dynamic", number_of_topics = 5,
-#'                      model_settings(time_index = time_index_vec, num_states = 5)
-#'                     )
+#'   bills_time_index <- keyATM_data_bills$time_index
+#'   # Time index should start from 1, increment by 1
+#'   bills_time_index <- as.integer(bills_time_index - 100)
+#'   out <- weightedLDA(keyATM_docs, model = "dynamic",
+#'          number_of_topics = 5,
+#'          model_settings = list(num_states = 5,
+#'                           time_index = bills_time_index))
 #'
 #'   # Visit our website for full examples: https://keyatm.github.io/keyATM/
 #'
@@ -226,7 +242,7 @@ weightedLDA <- function(docs, model, number_of_topics,
                       )
 
   # 0 iterations
-  if (options$iterations == 0) {
+  if (fitted$options$iterations == 0) {
     return(fitted) 
   }
 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ An R package for Keyword Assisted Topic Models, created by [Shusei Eshima](https
 
 # Website
 Please visit [our website](https://keyatm.github.io/keyATM/) for a complete reference.
+
+# Development version [![DevVersion](https://img.shields.io/badge/Dev-v0.2.0-orange)](https://github.com/keyATM/keyATM/tree/v0.2.0)
+We are preparing the next version. If you want to try it, you can install it with `devtools`.
+```r
+devtools::install_github("keyATM/keyATM", ref = "v0.2.0")
+```

--- a/man/keyATM.Rd
+++ b/man/keyATM.Rd
@@ -78,29 +78,36 @@ A keyATM_output object containing:
 Run keyATM models.
 }
 \examples{
-\dontrun{
+\donttest{
   library(keyATM)
   library(quanteda)
   data(keyATM_data_bills)
   bills_keywords <- keyATM_data_bills$keywords
   bills_dfm <- keyATM_data_bills$doc_dfm  # quanteda dfm object
   keyATM_docs <- keyATM_read(bills_dfm)
+
   # keyATM Base
-  out <- keyATM(
-                docs, model = "base", no_keyword_topics = 5, keywords = keywords_list
-               )
+  out <- keyATM(keyATM_docs,
+                model = "base", no_keyword_topics = 5,
+                keywords = bills_keywords)
 
   # keyATM Covariates
-  out <- keyATM(
-                docs, model = "covariates", no_keyword_topics = 5, keywords = keywords_list,
-                model_settings(covariates_data = cov, covariates_formula = ~ .)
-               )
+  bills_cov <- as.data.frame(keyATM_data_bills$cov)
+  out <- keyATM(keyATM_docs,
+         model = "covariates", no_keyword_topics = 5,
+         keywords = bills_keywords,
+         model_settings = list(covariates_data = bills_cov,
+         covariates_formula = ~RepParty))
 
   # keyATM Dynamic
-  out <- keyATM(
-                docs, model = "dynamic", no_keyword_topics = 5, keywords = keywords_list,
-                model_settings(time_index = time_index_vec, num_states = 5)
-               )
+  bills_time_index <- keyATM_data_bills$time_index
+  # Time index should start from 1, increment by 1
+  bills_time_index <- as.integer(bills_time_index - 100)
+  out <- keyATM(keyATM_docs,
+                model = "dynamic", no_keyword_topics = 5,
+                keywords = bills_keywords,
+                model_settings = list(num_states = 5,
+                time_index = bills_time_index, num_states = 5))
 
   # Visit our website for full examples: https://keyatm.github.io/keyATM/
 

--- a/man/weightedLDA.Rd
+++ b/man/weightedLDA.Rd
@@ -56,23 +56,32 @@ A keyATM_output object containing:
 Run weighted LDA models.
 }
 \examples{
-\dontrun{
+\donttest{
+  library(keyATM)
+  library(quanteda)
+  data(keyATM_data_bills)
+  bills_keywords <- keyATM_data_bills$keywords
+  bills_dfm <- keyATM_data_bills$doc_dfm  # quanteda dfm object
+  keyATM_docs <- keyATM_read(bills_dfm)
   # Weighted LDA
-  out <- weightedLDA(
-                     keyATM_docs, model = "base", number_of_topics = 5
-                    )
+  out <- weightedLDA(keyATM_docs, model = "base",
+                     number_of_topics = 5)
 
   # Weighted LDA Covariates
-  out <- weightedLDA(
-                     keyATM_docs, model = "covariates", number_of_topics = 5,
-                     model_settings(covariates_data = cov, covariates_formula = ~ .)
-                    )                   
+  bills_cov <- as.data.frame(keyATM_data_bills$cov)
+  out <- weightedLDA(keyATM_docs, model = "covariates",
+         number_of_topics = 5,
+         model_settings = list(covariates_data = bills_cov,
+         covariates_formula = ~ RepParty))                   
 
   # Weighted LDA Dynamic
-  out <- weightedLDA(
-                     keyATM_docs, model = "dynamic", number_of_topics = 5,
-                     model_settings(time_index = time_index_vec, num_states = 5)
-                    )
+  bills_time_index <- keyATM_data_bills$time_index
+  # Time index should start from 1, increment by 1
+  bills_time_index <- as.integer(bills_time_index - 100)
+  out <- weightedLDA(keyATM_docs, model = "dynamic",
+         number_of_topics = 5,
+         model_settings = list(num_states = 5,
+                          time_index = bills_time_index))
 
   # Visit our website for full examples: https://keyatm.github.io/keyATM/
 


### PR DESCRIPTION
Thanks for the package. I was so frustrated when the examples in the package were all not runnable. For example, the data was not loaded, the specifications for `model_settings` were all incorrect.

I think from a pedagogical perspective, it is better to make all examples runnable so that your users (e.g. me) can explore the package themselves. Of course, the website is nice, but it is quicker to just follow the examples.

From my experience of CRAN submission, the team would complain about code wrapped in `\dontrun`, when the code is supposed to be runnable by users (i.e. not subject to external conditions such as Twitter API accessibility, etc). If you simply don't want the examples to be tested in `R CMD CHECK` (either your machine or on CRAN's machine), you should wrap the code in `\donttest` instead.

Nonetheless, I have checked all examples with 

```r
devtools::run_examples(test = TRUE)
```

If you think I deserve to be an author with this PR, please add me to the `DESCRIPTION`

```r
person(given = "Chung-hong",
           family = "Chan",
           role = c("aut"),
           email = "chainsawtiney@gmail.com",
           comment = c(ORCID = "0000-0002-6232-7530"))
```