### PR TITLE
use just first 58 speeches of inaugural corpus in test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ warnings_are_errors: false
 os:
   - linux
   - osx
-dist: trusty
 latex: false
 env:
   global:

--- a/tests/testthat/test-keyATMHeterogeneity.R
+++ b/tests/testthat/test-keyATMHeterogeneity.R
@@ -11,6 +11,7 @@ if (!"dplyr" %in% rownames(installed.packages())) {
 }
 
 data(data_corpus_inaugural, package = "quanteda")
+data_corpus_inaugural <- head(data_corpus_inaugural, n = 58)
 data_tokens <- tokens(data_corpus_inaugural, remove_numbers = TRUE, 
                       remove_punct = TRUE, remove_symbols = TRUE,
                       remove_separators = TRUE, remove_url = TRUE) %>%
@@ -96,6 +97,3 @@ test_that("Topic Word", {
   expect_equivalent(top$Republican[1, 5], "war [\U2713]")
   expect_equivalent(top$Republican[3, 7], "done")
 })
-
-
-


### PR DESCRIPTION
Since it does change every 4 years, and did in Jan 2021. It now has 59 speeches.

We will be updating **quanteda** with this new data object soon, so please change your test before that. Thanks!