### PR TITLE
modify plot_topicprop()

### DIFF
--- a/man/plot_topicprop.Rd
+++ b/man/plot_topicprop.Rd
@@ -8,9 +8,10 @@ plot_topicprop(
   x,
   n = 3,
   show_topic = NULL,
-  xmax = NULL,
   show_topwords = TRUE,
-  label_topic = NULL
+  label_topic = NULL,
+  order = c("proportion", "topicid"),
+  xmax = NULL
 )
 }
 \arguments{
@@ -20,11 +21,13 @@ plot_topicprop(
 
 \item{show_topic}{an integer or a vector. Indicate topics to visualize. Default is \code{NULL}.}
 
-\item{xmax}{a numeric. Indicate the max value on the x axis}
-
 \item{show_topwords}{logical. Show topwords. The default is \code{TRUE}.}
 
 \item{label_topic}{a character vector. The name of the topics in the plot.}
+
+\item{order}{The order of topics.}
+
+\item{xmax}{a numeric. Indicate the max value on the x axis}
 }
 \value{
 keyATM_fig object

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -56,9 +56,11 @@ test_that("Plot pi", {
 
 test_that("Plot topic plot", {
   p <- plot_topicprop(base) ; expect_s3_class(p, "keyATM_fig")
+  p <- plot_topicprop(base, order = "topicid") ; expect_s3_class(p, "keyATM_fig")
   p <- plot_topicprop(base, n = 5) ; expect_s3_class(p, "keyATM_fig")
   p <- plot_topicprop(base, show_topwords = FALSE) ; expect_s3_class(p, "keyATM_fig")
   p <- plot_topicprop(base, show_topic = 1:3, label_topic = paste0("T", 1:3)) ; expect_s3_class(p, "keyATM_fig")
+  p <- plot_topicprop(base, show_topic = 1:3, label_topic = paste0("T", 1:3), order = "topicid") ; expect_s3_class(p, "keyATM_fig")
   p <- plot_topicprop(base, show_topic = c(1, 4, 7)) ; expect_s3_class(p, "keyATM_fig")
 
   expect_error(plot_topicprop(base, show_topic = -1))


### PR DESCRIPTION
I am wondering if we can order the topic by their proportion in the output figure of `plot_topicprop()`. 