### PR TITLE
Fixing semantic coherence function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Authors@R: c(person("Shusei", "Eshima", email = "shuseieshima@gmail.com", role =
     person("Kosuke", "Imai", email = "imai@harvard.edu", role = c("aut")),
     person("Chung-hong", "Chan", email = "chainsawtiney@gmail.com", role = c("ctb"), comment = c(ORCID = "0000-0002-6232-7530")),
     person(given = "Romain", family = "François", role = "ctb", comment = c(ORCID = "0000-0002-2444-4226")),
+    person(given = "Martin", family = "Feldkircher", role = "ctb", comment = c(ORCID = "0000-0002-5511-9215")),
     person("William", "Lowe", email = "wlowe@princeton.edu", role = c("ctb")),
     person("Seo-young Silvia", "Kim", email = "sy.silvia.kim@gmail.com", role = c("ctb"), comment = c(ORCID = "0000-0002-8801-9210")))
 License: GPL-3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # keyATM 0.5.2
 ### Minor changes
+* Fixing the semantic coherence function (use sum(row1) in the denominator)
 * Updating the paper information
 * Deleting the `save()` function (thank you [@AMindToThink](https://github.com/AMindToThink) for repoting this error in [#214](https://github.com/keyATM/keyATM/issues/214))
 

--- a/R/posterior.R
+++ b/R/posterior.R
@@ -787,7 +787,7 @@ semantic_coherence <- function(x, docs, n = 10) {
             purrr::map_dbl(
               ~ word_in_doc(.x, combn_top_words[2, x])
             )
-          out <- log((sum(row1 & row2) + 1) / sum(row2))
+          out <- log((sum(row1 & row2) + 1) / sum(row1))
           return(out)
         }
       ) %>%


### PR DESCRIPTION
Fix the semantic_coherence function such that it resembles equation (1) in Mimno et al (2011) (use sum(row1) in the denominator of the function)